### PR TITLE
pty_spawn.c: fix '_copy' build on clang

### DIFF
--- a/bicon/pty_spawn.c
+++ b/bicon/pty_spawn.c
@@ -93,7 +93,7 @@ _xwrite (
   }
 }
 
-static int
+static void
 _copy (
   int master_fd,
   reader master_read,


### PR DESCRIPTION
Without the change build on clang-13 fails as:

      pty_spawn.c:160:6: error: non-void function '_copy' should return a value [-Wreturn-type]
                  return;
                  ^